### PR TITLE
Disable multithreaded build

### DIFF
--- a/recipe/build_geant4.sh
+++ b/recipe/build_geant4.sh
@@ -38,7 +38,7 @@ cmake                                                          \
       -DBUILD_SHARED_LIBS=ON                                   \
       -DGEANT4_INSTALL_EXAMPLES=ON                             \
       -DGEANT4_INSTALL_DATA=OFF                                \
-      -DGEANT4_BUILD_MULTITHREADED=ON                          \
+      -DGEANT4_BUILD_MULTITHREADED=OFF                         \
       -DGEANT4_USE_GDML=ON                                     \
       ${CMAKE_PLATFORM_FLAGS[@]} \
       ${SRC_DIR}


### PR DESCRIPTION
The multithreaded build causes runtime problems when dlopen is used to
load plugins that have been linked against the geant4 shared libraries.
This is obvious when building a Python module using Cython that
uses the Geant4 API, which results in the runtime error:

libG4processes.so: cannot allocate memory in static TLS block

See also https://github.com/cms-sw/cmsdist/issues/265